### PR TITLE
fix: error is underestimated for removed projects in groundtruth

### DIFF
--- a/src/evaluators.py
+++ b/src/evaluators.py
@@ -1054,7 +1054,8 @@ class GitcoinEvaluator(RMSEEvaluator):
 
         ground_truth_df["AMOUNT2"] = pd.to_numeric(ground_truth_df["AMOUNT"])
         ground_truth_df["ROUND_ID"] = ground_truth_df["ROUND_ID"].astype(str)
-        ground_truth_df = ground_truth_df.merge(submission_df, on=["PROJECT_ID", "ROUND_ID"])
+        ground_truth_df = submission_df.merge(ground_truth_df, on=["PROJECT_ID", "ROUND_ID"], how="left")
+        ground_truth_df.fillna(0, inplace=True)
         ground_truth_df_grouped = ground_truth_df.groupby("ROUND_ID")
         ground_truth_df["LABEL"] = ground_truth_df_grouped["AMOUNT2"].transform(
             lambda x: x / x.sum() if x.sum() > 0 else 0


### PR DESCRIPTION
Ground_truth turns out to be a subset of submission. The projects not in ground_truth theoretically should have weight 0 and if the submission assigns non-zero weights to those projects then it should get more error.